### PR TITLE
Report version placeholder

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -12,7 +12,8 @@ summary_data = helpers.get_summary_information()
 severity_count_data = helpers.get_severity_counts()
 
 # Project name taken from summary_information.conf, inserted in Title section -> title.tex file
-REPLACE_TITLE = [["__PLACEHOLDER__PROJECT_NAME", summary_data['project_name']]]
+REPLACE_TITLE = [["__PLACEHOLDER__PROJECT_NAME", summary_data['project_name']],
+                 ["__PLACEHOLDER__REPORT_VERSION", summary_data['report_version']]]
 
 source_org, repo_name = re.search(r'/(?P<org_name>[^/]+)/([^/.]+)(?:\.git)?$', summary_data['project_github']).groups()
 

--- a/source/summary_information.conf
+++ b/source/summary_information.conf
@@ -2,6 +2,7 @@
 # This will be shown in the title page as "project_name Audit Report"
 # As auditors can be formatted further, their names are in lead_auditors.md and assisting_auditors.md
 project_name = PROJECT_NAME
+report_version = 1.0
 
 # team_name engaged with Cyfrin to review project_name
 team_name = TEAM_NAME

--- a/templates/title.tex
+++ b/templates/title.tex
@@ -41,7 +41,7 @@
     Prepared by \href{https://cyfrin.io}{Cyfrin}
 
     \large{
-      Version 1.0
+      Version __PLACEHOLDER__REPORT_VERSION
     }\\[1.2cm]
     
     \vfill


### PR DESCRIPTION
This PR adds a placeholder for the report version so auditors no longer have to edit the .tex file and can simply update the .conf file with the rest of the summary information.