### PR TITLE
fix: escape `&` in issue titles instead of rewriting to "and"

### DIFF
--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -6,7 +6,6 @@ from os.path import exists as check_file
 import os
 import re
 import subprocess
-from .linter import replace_ampersand_in_findings_headings
 
 # Define file paths
 SOURCE_PATH = './source/'
@@ -100,11 +99,9 @@ def markdown_heading_to_latex_hypertarget(heading):
 
 def escape_latex_special_chars(text):
     # Escape LaTeX special characters that can appear in issue titles.
-    # Note: '&' is already handled by replace_ampersand_in_findings_headings(),
-    # and '_' within backticks is handled by format_inline_code().
-    # We only escape chars not handled elsewhere that won't conflict with
-    # the \texttt{} commands produced by format_inline_code().
+    # '_' within backticks is handled separately by format_inline_code().
     replacements = [
+        ('&', '\\&'),
         ('%', '\\%'),
         ('$', '\\$'),
         ('#', '\\#'),
@@ -276,13 +273,12 @@ def get_issues(repository, github, filter_options=None):
 
         # Iterate through all findings for the current severity
         for counter, (issue_title, status_label) in enumerate(summary_of_findings[label], start=1):
-            linted_title = replace_ampersand_in_findings_headings(issue_title)
-            latex_hypertarget = markdown_heading_to_latex_hypertarget("### " + linted_title)
-            escaped_title = escape_latex_special_chars(linted_title)
+            latex_hypertarget = markdown_heading_to_latex_hypertarget("### " + issue_title)
+            escaped_title = escape_latex_special_chars(issue_title)
             prefixed_title = f"\hyperlink{{{latex_hypertarget}}}{{[{prefix}{str(counter).zfill(fill)}] {format_inline_code(escaped_title)}}}"
             status_label = status_label.replace("Report Status: ", "")
             summary_findings_table += f"{prefixed_title} & {status_label} \\\\\n\hline"
-            mitigation_table += f"\"{linted_title}\",{status_label},,\n"
+            mitigation_table += f"\"{issue_title}\",{status_label},,\n"
 
     # Replace the placeholder in the SUMMARY_TEX file
     placeholder_start = "% __PLACEHOLDER__SUMMARY_OF_FINDINGS_START"

--- a/scripts/linter.py
+++ b/scripts/linter.py
@@ -19,23 +19,12 @@ def replace_org_in_link(line, internal_org, internal_repo_name, source_org, sour
     return line
 
 
-def replace_ampersand_in_findings_headings(line):
-    # If the line is a finding markdown heading and contains '&', replace '&' with 'and'
-    if line.strip().startswith('###') and '&' in line:
-        line = line.replace('&', 'and')
-
-    return line
-
-
 def lint(report, team_name, source_org, source_repo_name, internal_org, internal_repo_name,):
     for line in report:
         new_line = line
-        
+
         # Replace any internal organization repo links
         new_line = replace_org_in_link(new_line, internal_org, internal_repo_name, source_org, source_repo_name)
-        
-        # Replace any '&' in finding headings with 'and'
-        new_line = replace_ampersand_in_findings_headings(new_line)
 
         # Replace any double backslashes with single backslashes (GitHub MathJax to LaTeX)
         new_line = new_line.replace('\\\\', '\\')


### PR DESCRIPTION
## Summary
- Escape `&` to `\&` in `escape_latex_special_chars` so titles like `` `&Vec<T>` parameter should be `&[T]` `` (Rust references) compile cleanly inside the summary-of-findings tabular.
- Drop `replace_ampersand_in_findings_headings` and its call. It only fired on lines starting with `###` (so raw issue titles never went through it), and where it did fire it mangled valid Rust code by turning `&` into "and".

## Why
A push of the report workflow on a real audit (Particle uni-acct-svm, Rust/Anchor) failed: pdflatex saw an unescaped `&` in a finding title rendered into `summary.tex` and bailed with "Misplaced \cr / Missing \cr inserted" → no PDF, then `mv main.pdf` failed the job.

Run that failed (vendored copy of this template):
https://github.com/Cyfrin/audit-2026-04-particle-uni-acct-svm/actions/runs/24944836359

## Test plan
- [x] Same diff applied to the vendored copy in the audit repo, pushed, and the workflow now compiles all 3 LaTeX passes and uploads PDF + md + csv: https://github.com/Cyfrin/audit-2026-04-particle-uni-acct-svm/actions/runs/24955416802
- [ ] Manual sanity-check on a report with no `&` in any title (existing audits should be unaffected since the only behavior change is on titles containing `&`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)